### PR TITLE
Update README.md: Add `--locked` to all cargo install invocations (minor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ brew install aranborkum/tap/tmuxedo
 #### Install from [crates.io](https://crates.io/crates/tmuxedo):
 
 ```bash
-cargo install tmuxedo
+cargo install --locked tmuxedo
 ```
 
 #### Or build from source:
@@ -40,7 +40,7 @@ cargo install tmuxedo
 ```bash
 git clone https://github.com/AranBorkum/tmuxedo
 cd tmuxedo
-cargo install --path .
+cargo install --locked --path .
 ```
 
 ---


### PR DESCRIPTION
I've seen issues with cargo tools where underlying dependencies have broken because dependency requirements were not restrictive enough.

I traced this deeply in a different project. (examples: MordechaiHadad/bob#277 and MordechaiHadad/bob#298)

The solution is to always install global tools with `--locked` to ensure that updated and untested dependencies don't sneak into the build.
